### PR TITLE
ignore *.mark file extensions for binaries

### DIFF
--- a/chapter-04/alive/makefile
+++ b/chapter-04/alive/makefile
@@ -1,5 +1,5 @@
 #makefile for alive.asm
 alive: alive.o
-	gcc -o alive alive.o -no-pie
+	gcc -o alive.mark alive.o -no-pie
 alive.o: alive.asm
 	nasm -f elf64 -g -F dwarf alive.asm -l alive.lst


### PR DESCRIPTION
use `.mark` file extension for binaries and gitignore them